### PR TITLE
summon: add hostAliases passthrough to pod spec

### DIFF
--- a/charts/glyphs/summon/templates/workload/_podSpec.tpl
+++ b/charts/glyphs/summon/templates/workload/_podSpec.tpl
@@ -84,6 +84,10 @@ affinity:
 tolerations:
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with $root.Values.hostAliases }}
+hostAliases:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- with $root.Values.imagePullSecrets }}
 imagePullSecrets:
     {{- toYaml . | nindent 2 }}
@@ -140,6 +144,10 @@ affinity:
   {{- end }}
   {{- with $root.Values.tolerations }}
 tolerations:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with $root.Values.hostAliases }}
+hostAliases:
     {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- with $root.Values.imagePullSecrets }}


### PR DESCRIPTION
Mirrors the existing nodeSelector/tolerations pattern. Needed to blackhole specific hostnames (e.g. Mojang session API) for offline-mode game servers without touching cluster-wide DNS.